### PR TITLE
Improve the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,26 +16,26 @@ ci: ## Run tests, linting and type checking
 	@uv run mypy rcav2
 	@uv run pytest --doctest-modules
 
-.PHONY: backend
-backend: ## Run the backend server
-	@uv run fastapi dev --host 0.0.0.0 --port 8080 ./rcav2/api.py
-
-.PHONY: frontend
-frontend: frontend-install frontend-build frontend-dev ## Run the frontend dev server
+.PHONY: serve
+serve: frontend-build backend-serve ## Run RCAv2 app with compiled assets
 
 .PHONY: release
 release: ## Create a release version of the app
 	npm run release
 	uv build
 
+.PHONY: backend-serve
+backend-serve: ## Serve the backend API server
+	@uv run fastapi dev --host 0.0.0.0 --port 8080 ./rcav2/api.py
 .PHONY: frontend-install
+
 frontend-install:
 	npm install
 
-.PHONY: frontend-dev
-frontend-dev:
+.PHONY: frontend-serve
+frontend-serve: frontend-install ## Start the frontend dev server
 	npm run dev
 
-.PHONY: frontend-build
+.PHONY: frontend-build ## Build a static version to be served by the api
 frontend-build:
 	npm run build

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,32 @@
+green := \033[36m
+white := \033[0m
+
+executables = uv npm
+T := $(foreach exec,$(executables),\
+        $(if $(shell which $(exec)),WARNING,$(error "No $(exec) in PATH")))
+
+.PHONY: help
+help: ## Prints help for targets with comments.
+	@cat $(MAKEFILE_LIST) | grep -E '^[a-zA-Z_-]+:.*?## .*$$' | awk 'BEGIN {FS = ":.*?## "}; {printf "$(green)%-30s$(white) %s\n", $$1, $$2}'
+
 .PHONY: ci
-ci:
+ci: ## Run tests, linting and type checking
 	@uv run ruff check --fix
 	@uv run ruff format
 	@uv run mypy rcav2
 	@uv run pytest --doctest-modules
 
-.PHONY: serve
-serve:
+.PHONY: backend
+backend: ## Run the backend server
 	@uv run fastapi dev --host 0.0.0.0 --port 8080 ./rcav2/api.py
+
+.PHONY: frontend
+frontend: frontend-install frontend-build frontend-dev ## Run the frontend dev server
+
+.PHONY: release
+release: ## Create a release version of the app
+	npm run release
+	uv build
 
 .PHONY: frontend-install
 frontend-install:
@@ -20,8 +39,3 @@ frontend-dev:
 .PHONY: frontend-build
 frontend-build:
 	npm run build
-
-.PHONY: release
-release:
-	npm run release
-	uv build

--- a/README.md
+++ b/README.md
@@ -33,33 +33,43 @@ $ uv run rcav2 $BUILD_URL
 [RCA will be printed here]
 ```
 
-### Web API
+## Development Environment
 
-The project also includes a FastAPI server. To run it for development:
+There are two primary ways to run the development environment, depending on your needs.
+
+### 1. Serve Backend with Compiled Frontend Assets
+
+This approach is ideal for testing the application as a single, unified service. The frontend is built into static assets and served directly by the backend.
+
+To run the application in this mode, use the following command:
+
 ```ShellSession
 make serve
 ```
 
-### Frontend
+This will:
+1. Build the frontend assets.
+2. Start the FastAPI backend server, which will also serve the frontend.
 
-The frontend requires Node.js version 20.19.2.
+### 2. Run Backend and Frontend as Separate Instances
 
-To install the dependencies:
+This setup is useful when you are actively developing the frontend and want to take advantage of hot-reloading features.
+
+**Start the Backend:**
+To run the backend API server, use:
 ```ShellSession
-make frontend-install
+make backend-serve
 ```
 
-To run the frontend development server:
+**Start the Frontend:**
+The frontend requires Node.js version 20.19.2. To install the dependencies and run the frontend development server, use:
 ```ShellSession
-make frontend-dev
+make frontend-serve
 ```
 
-To build the frontend:
-```ShellSession
-make frontend-build
-```
+This will start the Vite development server with hot-reloading enabled.
 
-## Development
+## Tests
 
 To validate your changes, run the continuous integration script:
 ```ShellSession


### PR DESCRIPTION
This PR refactors the `Makefile` to improve the developer experience.

**Changes:**

*   **Added `make help`:** A new self-documenting target that lists all available commands by parsing `##` comments.
*   **Added Dependency Checks:** The Makefile now verifies that `uv` and `npm` are in the `PATH` before running, exiting with an error i
f they are missing.
*   **Renamed `serve` to `backend`:** The target for running the backend server is now more descriptively named `make backend`.
*   **Added `make frontend`:** A new convenience target that installs dependencies, builds, and runs the frontend development server with a single command.
*   **Improved Target Comments:** Added `##` comments to all targets to integrate with the new `help` command.